### PR TITLE
Package API and add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+get:
+	@echo ">> Getting any missing dependencies.."
+	go get -t ./...
+.PHONY: get
+
+install:
+	go install github.com/battlesnakeio/starter-snake-go
+.PHONY: install
+
+run: install
+	starter-snake-go server
+.PHONY: run
+
+test:
+	go test ./...
+.PHONY: test
+
+fmt:
+	@echo ">> Running Gofmt.."
+	gofmt -l -s -w .

--- a/README.md
+++ b/README.md
@@ -20,19 +20,21 @@ git clone git@github.com:USERNAME/battlesnake-go.git $GOPATH/github.com/USERNAME
 cd $GOPATH/github.com/USERNAME/battlesnake-go
 ```
 
-3) Compile the battlesnake-go server.
-```
-go build
-```
-This will create a `battlesnake-go` executable.
+3) Compile and run the server with:
 
-4) Run the server.
 ```
-./battlesnake-go
+Make run
 ```
 
-5) Test the client in your browser: [http://127.0.0.1:9000/start](http://127.0.0.1:9000/start)
+4) Test the client in your browser: [http://127.0.0.1:9000/start](http://127.0.0.1:9000/start)
 
+### Running tests locally
+
+```
+Make test
+```
+
+Note: if you're missing any packages, use `Make get`.
 
 ### Deploying to Heroku
 

--- a/api/api.go
+++ b/api/api.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"encoding/json"

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"bytes"

--- a/routes.go
+++ b/routes.go
@@ -3,30 +3,32 @@ package main
 import (
 	"log"
 	"net/http"
+
+  "github.com/battlesnakeio/starter-snake-go/api"
 )
 
 func Start(res http.ResponseWriter, req *http.Request) {
-	decoded := SnakeRequest{}
-	err := DecodeSnakeRequest(req, &decoded)
+	decoded := api.SnakeRequest{}
+	err := api.DecodeSnakeRequest(req, &decoded)
 	if err != nil {
 		log.Printf("Bad start request: %v", err)
 	}
 	dump(decoded)
 
-	respond(res, StartResponse{
+	respond(res, api.StartResponse{
 		Color: "#75CEDD",
 	})
 }
 
 func Move(res http.ResponseWriter, req *http.Request) {
-	decoded := SnakeRequest{}
-	err := DecodeSnakeRequest(req, &decoded)
+	decoded := api.SnakeRequest{}
+	err := api.DecodeSnakeRequest(req, &decoded)
 	if err != nil {
 		log.Printf("Bad move request: %v", err)
 	}
 	dump(decoded)
 
-	respond(res, MoveResponse{
+	respond(res, api.MoveResponse{
 		Move: "down",
 	})
 }


### PR DESCRIPTION
# Summary

1. I'm making a serverless starter snake in go and instead of creating my own battlesnake api structs I thought I'd use what's existing in the `starter-snake-go` repo. In order to do that, `api.go` will need to be its own package;  that way I can _import  "github.com/battlesnakeio/starter-snake-go/api"_.

1. Added a `Makefile` with basic commands for installing, running, testing, and fetching any packages. Oh and there's a command in there for formatting the code. 

1. Modified the instructions in the README to reference the Makefile instead. 
